### PR TITLE
Fixing path replacement to handle windows paths

### DIFF
--- a/src/main/java/com/github/rzabini/org/approvaltests/spock/ApprovalNamerWithCustomPath.java
+++ b/src/main/java/com/github/rzabini/org/approvaltests/spock/ApprovalNamerWithCustomPath.java
@@ -20,6 +20,6 @@ public class ApprovalNamerWithCustomPath implements ApprovalNamer {
 
     @Override
     public String getSourceFilePath() {
-        return approvalNamer.getSourceFilePath().replaceAll("test/(groovy|java)", "test/resources");
+        return approvalNamer.getSourceFilePath().replaceAll("test(\\/|\\\\)(groovy|java)", "test$1resources");
     }
 }

--- a/src/test/groovy/com/github/rzabini/org/approvaltests/spock/ApprovalNamerSpecification.groovy
+++ b/src/test/groovy/com/github/rzabini/org/approvaltests/spock/ApprovalNamerSpecification.groovy
@@ -1,0 +1,24 @@
+package com.github.rzabini.org.approvaltests.spock
+
+import org.approvaltests.namer.ApprovalNamer
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ApprovalNamerSpecification extends Specification {
+
+    def testPathRenamer() {
+        given:
+        def spockNamer = Mock(ApprovalNamer)
+        spockNamer.getSourceFilePath() >> path
+
+        ApprovalNamerWithCustomPath customNamer = new ApprovalNamerWithCustomPath(spockNamer);
+
+        expect:
+        customNamer.getSourceFilePath().equals(targetPath)
+
+        where:
+        path                                                                             | targetPath
+        "C:\\Users\\username\\src\\gwp-api-tests\\.\\src\\test\\groovy\\com\\jhi\\gwp\\" | "C:\\Users\\username\\src\\gwp-api-tests\\.\\src\\test\\resources\\com\\jhi\\gwp\\"
+        "/Users/username/src/gwp-api-tests/./src/test/groovy/com/jhi/gwp/"               | "/Users/username/src/gwp-api-tests/./src/test/resources/com/jhi/gwp/"
+    }
+}


### PR DESCRIPTION
On windows filesystems the string replacement does not correctly handle groovy --> resources because the path delimiter is different